### PR TITLE
Enable not default plugins properly

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -47,8 +47,6 @@ export function compress(context) {
             params: {
               overrides: {
                 inlineStyles: false,
-                convertStyleToAttrs: true,
-                cleanupListOfValues: true,
                 removeViewBox: false,
                 cleanupEnableBackground: false,
                 removeHiddenElems: false,
@@ -56,10 +54,12 @@ export function compress(context) {
                 moveElemsAttrsToGroup: false,
                 moveGroupAttrsToElems: false,
                 convertPathData: false,
-                sortAttrs: true,
               }
             }
-          }
+          },
+          'convertStyleToAttrs',
+          'cleanupListOfValues',
+          'sortAttrs'
         ],
       }
       const config = { ...defaultConfig, ...externalConfig }


### PR DESCRIPTION
convertStyleToAttrs, cleanupListOfValues and sortAttrs plugins are not part of default preset. Preset allows only to disable and configure plugins.